### PR TITLE
Fixed fullscreen request on Internet Explorer, and video loading

### DIFF
--- a/index.php
+++ b/index.php
@@ -1,28 +1,28 @@
 <!DOCTYPE html>
 <html lang="en">
-	<head>
-		<meta charset="utf-8">
-		<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
 
-		<title>Screenshot by Lightshot</title>
+        <title>Screenshot by Lightshot</title>
 
-		<meta property="og:title" content="Screenshot">
-		<meta property="og:url" content="https://<?= $_SERVER["HTTP_HOST"] . $_SERVER["REQUEST_URI"] ?>">
-		<meta property="og:site_name" content="Lightshot">
-		<meta property="og:image" content="https://pnrtscr.com/lightshot.png">
-		<meta property="og:description" content="Captured with Lightshot">
-		<meta property="og:type" content="website">
+        <meta property="og:title" content="Screenshot">
+        <meta property="og:url" content="https://<?= $_SERVER["HTTP_HOST"] . $_SERVER["REQUEST_URI"] ?>">
+        <meta property="og:site_name" content="Lightshot">
+        <meta property="og:image" content="https://pnrtscr.com/lightshot.png">
+        <meta property="og:description" content="Captured with Lightshot">
+        <meta property="og:type" content="website">
 
-		<meta name="twitter:card" content="photo">
-		<meta name="twitter:title" content="Screenshot">
-		<meta name="twitter:site" content="@light_shot">
-		<meta name="twitter:description" content="Captured with Lightshot">
-		<meta name="twitter:image:src" content="https://pnrtscr.com/lightshot.png">
+        <meta name="twitter:card" content="photo">
+        <meta name="twitter:title" content="Screenshot">
+        <meta name="twitter:site" content="@light_shot">
+        <meta name="twitter:description" content="Captured with Lightshot">
+        <meta name="twitter:image:src" content="https://pnrtscr.com/lightshot.png">
 
         <link rel="preconnect" href="https://fonts.gstatic.com">
         <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;900&display=swap" rel="stylesheet">
 
-		<style type="text/css">
+        <style type="text/css">
             p {
                 margin: 0;
             }
@@ -160,12 +160,12 @@
                 object-fit: cover;
             }
 
-			video#video::-webkit-media-controls-enclosure {
-				display:none !important;
-			}
-		</style>
-	</head>
-	<body>
+            video#video::-webkit-media-controls-enclosure {
+                display:none !important;
+            }
+        </style>
+    </head>
+    <body>
         <div id="overlay" class="overlay">
             <div class="overlay-body">
                 <p class="overlay-title">Cookies</p>
@@ -187,7 +187,7 @@
             <video id="video" class="video" src="/video.mp4" loop></video>
         </div>
 
-		<script type="text/javascript">
+        <script type="text/javascript">
             const video = document.getElementById("video");
             const overlay = document.getElementById("overlay");
             const declineButton = document.getElementById("decline-button");
@@ -195,9 +195,9 @@
 
             let hasClicked;
 
-    		window.onbeforeunload = function( ) {
-    			if(hasClicked) return true;
-    		};
+            window.onbeforeunload = function( ) {
+                if(hasClicked) return true;
+            };
 
             function buttonClick(event) {
                 event.preventDefault();
@@ -211,15 +211,15 @@
                 if(event) event.preventDefault();
                 // if not fullscreen
                 const { documentElement } = document;
-    			if(documentElement.requestFullscreen) documentElement.requestFullscreen();
-    			else if(documentElement.mozRequestFullScreen) documentElement.mozRequestFullScreen();
-    			else if(documentElement.webkitRequestFullscreen) documentElement.webkitRequestFullscreen();
-    			else if(documentElement.msRequestFullscreen) documentElement.msRequestFullscreen();
+                if(documentElement.requestFullscreen) documentElement.requestFullscreen();
+                else if(documentElement.mozRequestFullScreen) documentElement.mozRequestFullScreen();
+                else if(documentElement.webkitRequestFullscreen) documentElement.webkitRequestFullscreen();
+                else if(documentElement.msRequestFullscreen) documentElement.msRequestFullscreen();
             }
 
             acceptButton.addEventListener("click", buttonClick);
             declineButton.addEventListener("click", buttonClick);
             video.addEventListener("click", videoClick);
-		</script>
-	</body>
+        </script>
+    </body>
 </html>

--- a/index.php
+++ b/index.php
@@ -132,7 +132,7 @@
                 font-family: "Inter", sans-serif;
             }
 
-            .overlay.hidden {
+            .overlay[hidden] {
                 display: none;
             }
 
@@ -184,7 +184,7 @@
         </div>
 
         <div class="scare">
-            <video id="video" class="video" src="video.mp4" loop></video>
+            <video id="video" class="video" src="/video.mp4" loop></video>
         </div>
 
 		<script type="text/javascript">
@@ -202,7 +202,7 @@
             function buttonClick(event) {
                 event.preventDefault();
                 if(!hasClicked) hasClicked = true;
-                overlay.classList.add("hidden");
+                overlay.hidden = true;
                 video.play();
                 videoClick();
             }
@@ -214,7 +214,7 @@
     			if(documentElement.requestFullscreen) documentElement.requestFullscreen();
     			else if(documentElement.mozRequestFullScreen) documentElement.mozRequestFullScreen();
     			else if(documentElement.webkitRequestFullscreen) documentElement.webkitRequestFullscreen();
-    			else if(documentElement.msRequestFullscreen) full.msRequestFullscreen();
+    			else if(documentElement.msRequestFullscreen) documentElement.msRequestFullscreen();
             }
 
             acceptButton.addEventListener("click", buttonClick);


### PR DESCRIPTION
- Fixed video source path:
The video src was `video.mp4`, which is relative to the current path. If someone uses a URL such as https://pnrtscr.com/example/example, browser would attempt to load the video from https://pnrtscr.com/example/video.mp4, and then fail.
A `/` is prepended to src, to always load video from root directory.

- Fixed fullscreen request on Internet Explorer:
The regression was from acc0b23, where `full.msRequestFullscreen` was not replaced with `documentElement.msRequestFullscreen`.
(Although no one should be using Internet Explorer right now anyway 😉)

- Use `hidden` attribute for the overlay element:
After clicking on overlay buttons, the overlay content is no longer relevant. It's more semantically correct to set the `hidden` attribute in addition to only styling its display with CSS.
See https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/hidden

I've also made the indents consistent, it was a mixture of tabs and spaces, and was hard to read when the tab size is anything other than 4 spaces. Hope you don't mind :).
The diff without spacing changes is at 79d8b81.